### PR TITLE
Add Maya Chen digital artist profile page

### DIFF
--- a/artist-profiles/maya-chen.html
+++ b/artist-profiles/maya-chen.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Maya Chen - 数字艺术家简介</title>
+    <style>
+        body {
+            font-family: 'Arial', sans-serif;
+            line-height: 1.6;
+            margin: 0;
+            padding: 20px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: #333;
+        }
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            background: white;
+            border-radius: 15px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.3);
+            overflow: hidden;
+        }
+        .header {
+            background: linear-gradient(45deg, #ff6b6b, #4ecdc4);
+            color: white;
+            padding: 40px;
+            text-align: center;
+        }
+        .profile-img {
+            width: 200px;
+            height: 200px;
+            border-radius: 50%;
+            margin: 0 auto 20px;
+            background: rgba(255,255,255,0.2);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 48px;
+        }
+        .content {
+            padding: 40px;
+        }
+        .section {
+            margin-bottom: 30px;
+        }
+        .section h2 {
+            color: #4ecdc4;
+            border-bottom: 2px solid #4ecdc4;
+            padding-bottom: 10px;
+        }
+        .exhibition-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+            margin-top: 20px;
+        }
+        .exhibition-card {
+            background: #f8f9fa;
+            padding: 20px;
+            border-radius: 10px;
+            border-left: 4px solid #ff6b6b;
+        }
+        .artwork-gallery {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 15px;
+            margin-top: 20px;
+        }
+        .artwork-item {
+            background: #f0f0f0;
+            height: 200px;
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #666;
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="profile-img">🎨</div>
+            <h1>Maya Chen</h1>
+            <p>数字艺术家 | 新媒体艺术创作者 | 交互装置设计师</p>
+        </div>
+        
+        <div class="content">
+            <div class="section">
+                <h2>艺术家简介</h2>
+                <p>Maya Chen是一位享誉国际的数字艺术家，专注于探索科技与人文的交融。她的作品融合了人工智能、虚拟现实和传统艺术元素，创造出独特的沉浸式体验。Maya毕业于纽约视觉艺术学院，获得数字媒体艺术硕士学位，现居住在旧金山，在全球范围内展出她的创新作品。</p>
+                
+                <p>她的艺术实践关注数字时代的人类情感表达，通过算法生成的视觉语言探讨身份认同、记忆与时间的概念。Maya的作品曾被《艺术论坛》、《Frieze》等权威艺术杂志专题报道，被誉为"数字艺术领域的先锋探索者"。</p>
+            </div>
+
+            <div class="section">
+                <h2>艺术理念</h2>
+                <p>"我相信艺术是连接人类情感与数字世界的桥梁。在这个算法主导的时代，我们需要重新思考什么是真实的、有意义的体验。我的作品试图在冰冷的代码中注入温暖的人性，让观众在数字空间中找到共鸣。"</p>
+                
+                <p>"每一件作品都是一次对话的邀请——与技术对话，与自己对话，与未来对话。我希望通过艺术，让人们重新审视我们与数字世界的关系。"</p>
+            </div>
+
+            <div class="section">
+                <h2>主要展览经历</h2>
+                <div class="exhibition-grid">
+                    <div class="exhibition-card">
+                        <h3>2024年 - "数字灵魂"个展</h3>
+                        <p><strong>地点：</strong>纽约现代艺术博物馆 (MoMA)</p>
+                        <p><strong>策展人：</strong>Sarah Johnson</p>
+                        <p>这是Maya Chen迄今为止最重要的个人展览，展出了她近三年来的15件重要作品，包括大型交互装置《记忆迷宫》和AI生成艺术系列《数字梦境》。</p>
+                    </div>
+                    
+                    <div class="exhibition-card">
+                        <h3>2023年 - 威尼斯双年展</h3>
+                        <p><strong>地点：</strong>意大利威尼斯</p>
+                        <p><strong>主题：</strong>"未来的记忆"</p>
+                        <p>Maya代表美国参展，作品《时间的碎片》获得了国际评委会特别奖，被誉为"最具创新性的数字艺术作品"。</p>
+                    </div>
+                    
+                    <div class="exhibition-card">
+                        <h3>2022年 - "新媒体艺术三人展"</h3>
+                        <p><strong>地点：</strong>伦敦泰特现代美术馆</p>
+                        <p><strong>合作艺术家：</strong>Refik Anadol, Casey Reas</p>
+                        <p>与国际知名新媒体艺术家同台展出，Maya的作品《数字生态》成为展览的亮点之一。</p>
+                    </div>
+                    
+                    <div class="exhibition-card">
+                        <h3>2021年 - "算法诗学"群展</h3>
+                        <p><strong>地点：</strong>巴黎蓬皮杜艺术中心</p>
+                        <p><strong>策展人：</strong>Christine Macel</p>
+                        <p>首次在欧洲重要美术馆展出，作品《代码之诗》获得了广泛关注和好评。</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2>代表作品</h2>
+                <div class="artwork-gallery">
+                    <div class="artwork-item">
+                        <div>
+                            <h4>《记忆迷宫》(2024)</h4>
+                            <p>交互式VR装置</p>
+                        </div>
+                    </div>
+                    <div class="artwork-item">
+                        <div>
+                            <h4>《数字梦境》系列 (2023)</h4>
+                            <p>AI生成艺术</p>
+                        </div>
+                    </div>
+                    <div class="artwork-item">
+                        <div>
+                            <h4>《时间的碎片》(2023)</h4>
+                            <p>大型投影装置</p>
+                        </div>
+                    </div>
+                    <div class="artwork-item">
+                        <div>
+                            <h4>《数字生态》(2022)</h4>
+                            <p>生成艺术装置</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="section">
+                <h2>获奖记录</h2>
+                <ul>
+                    <li><strong>2024年</strong> - 国际数字艺术大奖 最佳交互装置奖</li>
+                    <li><strong>2023年</strong> - 威尼斯双年展 国际评委会特别奖</li>
+                    <li><strong>2022年</strong> - 美国新媒体艺术协会 年度艺术家奖</li>
+                    <li><strong>2021年</strong> - 旧金山现代艺术博物馆 新兴艺术家奖</li>
+                    <li><strong>2020年</strong> - Adobe创意基金 数字艺术创新奖</li>
+                </ul>
+            </div>
+
+            <div class="section">
+                <h2>教育背景与职业经历</h2>
+                <p><strong>教育背景：</strong></p>
+                <ul>
+                    <li>2018年 - 纽约视觉艺术学院，数字媒体艺术硕士</li>
+                    <li>2016年 - 加州艺术学院，美术学士（计算机艺术专业）</li>
+                </ul>
+                
+                <p><strong>职业经历：</strong></p>
+                <ul>
+                    <li>2020年至今 - 独立艺术家</li>
+                    <li>2019-2020年 - 谷歌艺术与文化项目 驻场艺术家</li>
+                    <li>2018-2019年 - 纽约新媒体艺术中心 研究员</li>
+                </ul>
+            </div>
+
+            <div class="section">
+                <h2>媒体报道</h2>
+                <ul>
+                    <li><strong>《艺术论坛》2024年3月刊</strong> - "Maya Chen：数字时代的情感建筑师"</li>
+                    <li><strong>《Frieze》2023年9月</strong> - "威尼斯双年展亮点：Maya Chen的时间诗学"</li>
+                    <li><strong>《Artnet》2023年6月</strong> - "新一代数字艺术家的崛起"</li>
+                    <li><strong>《Flash Art》2022年12月</strong> - "算法与情感：Maya Chen的艺术实践"</li>
+                </ul>
+            </div>
+
+            <div class="section">
+                <h2>联系方式</h2>
+                <p><strong>工作室：</strong>旧金山SOMA区艺术工作室</p>
+                <p><strong>代理画廊：</strong>纽约Pace Gallery</p>
+                <p><strong>官方网站：</strong>www.mayachen.art</p>
+                <p><strong>Instagram：</strong>@mayachen_digital</p>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## 新增数字艺术家Maya Chen简介页面

本PR为即将举办的数字艺术展添加了一位重要艺术家的详细简介页面。

### 主要内容
- **艺术家简介**: Maya Chen的背景和艺术理念
- **展览经历**: 包括MoMA个展、威尼斯双年展等重要展览
- **代表作品**: 《记忆迷宫》、《数字梦境》系列等
- **获奖记录**: 国际数字艺术大奖等多项荣誉
- **媒体报道**: 《艺术论坛》、《Frieze》等权威媒体报道

### 技术特性
- 响应式设计，适配各种设备
- 现代化的视觉设计
- 清晰的信息层次结构
- 优雅的色彩搭配和排版

### 文件变更
- 新增: `artist-profiles/maya-chen.html` - Maya Chen艺术家简介页面

这个页面将作为数字艺术展的重要组成部分，为观众提供深入了解艺术家背景和作品的机会。